### PR TITLE
Pass `-g` to the linker to preserve debug info

### DIFF
--- a/src/zig.rs
+++ b/src/zig.rs
@@ -184,17 +184,18 @@ pub fn prepare_zig_linker(target: &str) -> Result<(PathBuf, PathBuf)> {
     let file_ext = if cfg!(windows) { "bat" } else { "sh" };
     let zig_cc = format!("zigcc-{}.{}", target, file_ext);
     let zig_cxx = format!("zigcxx-{}.{}", target, file_ext);
+    let cc_args = "-g"; // prevent stripping
     let cc_args = match triple.operating_system {
         OperatingSystem::Linux => format!(
-            "-target {}-linux-{}{}",
-            arch, triple.environment, abi_suffix
+            "-target {}-linux-{}{} {}",
+            arch, triple.environment, abi_suffix, cc_args,
         ),
         OperatingSystem::MacOSX { .. } | OperatingSystem::Darwin => {
-            format!("-target {}-macos-gnu{}", arch, abi_suffix)
+            format!("-target {}-macos-gnu{} {}", arch, abi_suffix, cc_args)
         }
         OperatingSystem::Windows { .. } => format!(
-            "-target {}-windows-{}{}",
-            arch, triple.environment, abi_suffix
+            "-target {}-windows-{}{} {}",
+            arch, triple.environment, abi_suffix, cc_args,
         ),
         _ => bail!("unsupported target"),
     };


### PR DESCRIPTION
For some reason the linker strips away the debug information by default, making it impossible to debug or profile the produced executable file or to produce a meaningful backtrace on panic. This PR adds `-g` to the linker invocation parameter to prevent stripping.

<details>
<summary>Panic message comparison</summary>

Without `-g`:

```
thread 'main' panicked at 'User-requested panic', main.rs:11:5
stack backtrace:
   0:       0x55574522e8 - <unknown>
   1:       0x555746f7ec - <unknown>
   2:       0x555744ef48 - <unknown>
   3:       0x5557453b80 - <unknown>
   4:       0x555745373c - <unknown>
   5:       0x5557454340 - <unknown>
   6:       0x5557453e0c - <unknown>
   7:       0x55574527a0 - <unknown>
    ⋮ 
```

With `-g`:

```
thread 'main' panicked at 'User-requested panic', main.rs:11:5
stack backtrace:
   0:       0x55722922e8 - std::backtrace_rs::backtrace::libunwind::trace::h93b3238ee24363ff
                               at /rustc/db9d1b20bba1968c1ec1fc49616d4742c1725b4b/library/std/src/../../backtrace/src/backtrace/libunwind.rs:93:5
   1:       0x55722922e8 - std::backtrace_rs::backtrace::trace_unsynchronized::hd0b91c595765251c
                               at /rustc/db9d1b20bba1968c1ec1fc49616d4742c1725b4b/library/std/src/../../backtrace/src/backtrace/mod.rs:66:5
   2:       0x55722922e8 - std::sys_common::backtrace::_print_fmt::h30044c15f37f55e5
                               at /rustc/db9d1b20bba1968c1ec1fc49616d4742c1725b4b/library/std/src/sys_common/backtrace.rs:67:5
   3:       0x55722922e8 - <std::sys_common::backtrace::_print::DisplayBacktrace as core::fmt::Display>::fmt::h3e879cfd83c3e738
                               at /rustc/db9d1b20bba1968c1ec1fc49616d4742c1725b4b/library/std/src/sys_common/backtrace.rs:46:22
   4:       0x55722af7ec - core::fmt::write::h0d0a553933f27920
                               at /rustc/db9d1b20bba1968c1ec1fc49616d4742c1725b4b/library/core/src/fmt/mod.rs:1149:17
   5:       0x557228ef48 - std::io::Write::write_fmt::h6441aebd0d25cafa
                               at /rustc/db9d1b20bba1968c1ec1fc49616d4742c1725b4b/library/std/src/io/mod.rs:1697:15
   6:       0x5572293b80 - std::sys_common::backtrace::_print::h59c3f7ca96dcfa56
                               at /rustc/db9d1b20bba1968c1ec1fc49616d4742c1725b4b/library/std/src/sys_common/backtrace.rs:49:5
   7:       0x5572293b80 - std::sys_common::backtrace::print::he3a1a4c8e3f2b5c5
                               at /rustc/db9d1b20bba1968c1ec1fc49616d4742c1725b4b/library/std/src/sys_common/backtrace.rs:36:9
   8:       0x5572293b80 - std::panicking::default_hook::{{closure}}::h0e439cefcb09f19c
                               at /rustc/db9d1b20bba1968c1ec1fc49616d4742c1725b4b/library/std/src/panicking.rs:211:50
   9:       0x557229373c - std::panicking::default_hook::h0d25e18a244e112d
                               at /rustc/db9d1b20bba1968c1ec1fc49616d4742c1725b4b/library/std/src/panicking.rs:228:9
  10:       0x5572294340 - std::panicking::rust_panic_with_hook::he2d8fa5b78d61952
                               at /rustc/db9d1b20bba1968c1ec1fc49616d4742c1725b4b/library/std/src/panicking.rs:606:17
  11:       0x5572293e0c - std::panicking::begin_panic_handler::{{closure}}::h17be8acecdbc2a5f
                               at /rustc/db9d1b20bba1968c1ec1fc49616d4742c1725b4b/library/std/src/panicking.rs:500:13
  12:       0x55722927a0 - std::sys_common::backtrace::__rust_end_short_backtrace::h8cecb3628cc0cdc8
                               at /rustc/db9d1b20bba1968c1ec1fc49616d4742c1725b4b/library/std/src/sys_common/backtrace.rs:139:18
  13:       0x5572293da0 - rust_begin_unwind
                               at /rustc/db9d1b20bba1968c1ec1fc49616d4742c1725b4b/library/std/src/panicking.rs:498:5
  14:       0x55722ae024 - core::panicking::panic_fmt::hffea458b8dc29080
                               at /rustc/db9d1b20bba1968c1ec1fc49616d4742c1725b4b/library/core/src/panicking.rs:107:14
  ⋮
```

</details>

Even with this PR, it's still possible to strip symbols and debug information by using the unstable [`profile.*.strip`](https://doc.rust-lang.org/1.58.1/cargo/reference/unstable.html#profile-strip-option) Cargo option, the stable [`-C strip=*`](https://doc.rust-lang.org/1.58.1/rustc/codegen-options/index.html#strip) rustc option, or an external strip tool.

The size-wise difference between letting the linker do stripping and apply stripping manually seems to be minuscule:

```shell
# Without `-g`:
$ ls -l target/aarch64-unknown-linux-gnu/release/program
... 2076992 ... target/aarch64-unknown-linux-gnu/release/program

# With `-g`:
$ ls -l target/aarch64-unknown-linux-gnu/release/program
... 6982112 ... target/aarch64-unknown-linux-gnu/release/program
$ strip target/aarch64-unknown-linux-gnu/release/program
$ ls -l target/aarch64-unknown-linux-gnu/release/program
... 2076984 ... target/aarch64-unknown-linux-gnu/release/program
```

