### PR TITLE
Use /usr/bin/env to locate the bash interpreter

### DIFF
--- a/src/zig.rs
+++ b/src/zig.rs
@@ -229,7 +229,7 @@ fn write_linker_wrapper(path: &Path, command: &str, args: &str) -> Result<()> {
     } else {
         env::current_exe()?
     };
-    writeln!(&mut custom_linker_file, "#!/bin/bash")?;
+    writeln!(&mut custom_linker_file, "#!/usr/bin/env bash")?;
     writeln!(
         &mut custom_linker_file,
         "{} zig {} -- {} $@",


### PR DESCRIPTION
Fixes #7