### PR TITLE
Enable unstable `target-applies-to-host` option automatically for nightly Rust

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -24,12 +24,13 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
+        toolchain: [stable, nightly]
     steps:
       - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: stable
+          toolchain: ${{ matrix.toolchain }}
           override: true
       - name: Cache cargo build
         uses: Swatinem/rust-cache@v1
@@ -42,6 +43,10 @@ jobs:
         if: matrix.os == 'ubuntu-latest'
         run: |
           cargo run zigbuild --target x86_64-unknown-linux-gnu
+      - name: Linux - Test x86_64 glibc build
+        if: ${{ matrix.os == 'ubuntu-latest' && matrix.toolchain == 'nightly' }}
+        run: |
+          cargo run zigbuild --target x86_64-unknown-linux-gnu.2.17
       - name: Linux - Test glibc build
         run: |
           rustup target add aarch64-unknown-linux-gnu

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,9 +4,9 @@ version = 3
 
 [[package]]
 name = "anyhow"
-version = "1.0.54"
+version = "1.0.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a99269dff3bc004caa411f38845c20303f1e393ca2bd6581576fa3a7f59577d"
+checksum = "159bb86af3a200e19a068f4224eae4c8bb2d0fa054c7e5d1cacd5cef95e684cd"
 
 [[package]]
 name = "atty"
@@ -39,6 +39,7 @@ dependencies = [
  "clap",
  "dirs",
  "fs-err",
+ "rustc_version",
  "semver",
  "target-lexicon",
 ]
@@ -51,9 +52,9 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "clap"
-version = "3.1.0"
+version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5f1fea81f183005ced9e59cdb01737ef2423956dac5a6d731b06b2ecfaa3467"
+checksum = "6d76c22c9b9b215eeb8d016ad3a90417bd13cb24cf8142756e6472445876cab7"
 dependencies = [
  "atty",
  "bitflags",
@@ -237,10 +238,19 @@ dependencies = [
 ]
 
 [[package]]
-name = "semver"
-version = "1.0.5"
+name = "rustc_version"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0486718e92ec9a68fbed73bb5ef687d71103b142595b406835649bebd33f72c7"
+checksum = "bfa0f585226d2e68097d4f95d113b15b83a82e819ab25717ec0590d9584ef366"
+dependencies = [
+ "semver",
+]
+
+[[package]]
+name = "semver"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4a3381e03edd24287172047536f20cabde766e2cd3e65e6b00fb3af51c4f38d"
 
 [[package]]
 name = "strsim"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,5 +15,6 @@ anyhow = "1.0.53"
 clap = { version = "3.1.0", features = ["derive", "env", "wrap_help"] }
 dirs = "4.0.0"
 fs-err = "2.6.0"
+rustc_version = "0.4.0"
 semver = "1.0.5"
 target-lexicon = "0.12.3"

--- a/src/zig.rs
+++ b/src/zig.rs
@@ -69,6 +69,9 @@ impl Zig {
                 if arg.ends_with(".rlib") && arg.contains("liblibc-") {
                     return None;
                 }
+                if arg == "-lc" {
+                    return None;
+                }
             }
             Some(arg.to_string())
         };


### PR DESCRIPTION
Helps with #4 