### PR TITLE
Supporting the nightly flag -Zmultitarget

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -77,6 +77,20 @@ jobs:
       - uses: actions-rs/cargo@v1
         with:
           command: build
+      - name: macOS - Test build
+        run: |
+          rustup target add aarch64-apple-darwin
+          cargo run zigbuild --target aarch64-apple-darwin
+          cargo run zigbuild --target aarch64-apple-darwin --release
+      - name: macOS - Test build with SDKROOT
+        if: matrix.os == 'ubuntu-latest'
+        env:
+          SDK: MacOSX11.3.sdk
+        run: |
+          curl -sqL https://github.com/phracker/MacOSX-SDKs/releases/download/11.3/$SDK.tar.xz | tar -Jx
+          export SDKROOT=$PWD/$SDK
+
+          cargo run zigbuild --target aarch64-apple-darwin --manifest-path tests/hello-tls/Cargo.toml
       - name: Linux - Test x86_64 build
         if: matrix.os == 'ubuntu-latest'
         run: |
@@ -111,11 +125,6 @@ jobs:
           rustup target add aarch64-unknown-linux-musl
           cargo run zigbuild --target aarch64-unknown-linux-musl
           cargo run zigbuild --target aarch64-unknown-linux-musl --manifest-path tests/hello-rustls/Cargo.toml
-      - name: macOS - Test build
-        run: |
-          rustup target add aarch64-apple-darwin
-          cargo run zigbuild --target aarch64-apple-darwin
-          cargo run zigbuild --target aarch64-apple-darwin --release
       - name: Windows - Test gnu build
         run: |
           rustup target add x86_64-pc-windows-gnu

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -99,6 +99,15 @@ jobs:
         if: ${{ matrix.os == 'ubuntu-latest' && matrix.toolchain == 'nightly' }}
         run: |
           cargo run zigbuild --target x86_64-unknown-linux-gnu.2.17
+      - name: Linux - Test x86_64 glibc run
+        if: ${{ matrix.os == 'ubuntu-latest' && matrix.toolchain == 'nightly' }}
+        uses: addnab/docker-run-action@v3
+        with:
+          image: centos:7
+          options: -v ${{ github.workspace }}:/io -w /io
+          run: |
+            ./target/x86_64-unknown-linux-gnu/debug/cargo-zigbuild --help
+            ldd -r -v ./target/x86_64-unknown-linux-gnu/debug/cargo-zigbuild
       - name: Linux - Test glibc build
         run: |
           rustup target add aarch64-unknown-linux-gnu

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -51,7 +51,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-zigbuild"
-version = "0.6.7"
+version = "0.6.8"
 dependencies = [
  "anyhow",
  "cargo_metadata",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cargo-zigbuild"
-version = "0.6.7"
+version = "0.6.8"
 edition = "2018"
 description = "Compile Cargo project with zig as linker"
 license = "MIT"

--- a/src/build.rs
+++ b/src/build.rs
@@ -198,9 +198,7 @@ impl Build {
         let rust_targets = self
             .target
             .iter()
-            .map(|target| {
-                target.split_once('.').map(|(t, _)| t).unwrap_or(&target)
-            })
+            .map(|target| target.split_once('.').map(|(t, _)| t).unwrap_or(target))
             .collect::<Vec<&str>>();
 
         // collect cargo build arguments
@@ -326,17 +324,23 @@ impl Build {
                 // we only setup zig as linker when target isn't exactly the same as host target
                 if host_target != full_target {
                     if let Some(rust_target) = rust_targets.get(i) {
-                        let env_target = rust_target.to_uppercase().replace('-', "_");
+                        let env_target = rust_target.replace('-', "_");
                         let (zig_cc, zig_cxx) = prepare_zig_linker(full_target)?;
                         if is_mingw_shell() {
                             let zig_cc = zig_cc.to_slash_lossy();
-                            build.env(format!("CC_{}", env_target.to_lowercase()), &zig_cc);
-                            build.env(format!("CXX_{}", env_target.to_lowercase()), &zig_cxx.to_slash_lossy());
-                            build.env(format!("CARGO_TARGET_{}_LINKER", env_target), &zig_cc);
+                            build.env(format!("CC_{}", env_target), &zig_cc);
+                            build.env(format!("CXX_{}", env_target), &zig_cxx.to_slash_lossy());
+                            build.env(
+                                format!("CARGO_TARGET_{}_LINKER", env_target.to_uppercase()),
+                                &zig_cc,
+                            );
                         } else {
-                            build.env(format!("CC_{}", env_target.to_lowercase()), &zig_cc);
-                            build.env(format!("CXX_{}", env_target.to_lowercase()), &zig_cxx);
-                            build.env(format!("CARGO_TARGET_{}_LINKER", env_target), &zig_cc);
+                            build.env(format!("CC_{}", env_target), &zig_cc);
+                            build.env(format!("CXX_{}", env_target), &zig_cxx);
+                            build.env(
+                                format!("CARGO_TARGET_{}_LINKER", env_target.to_uppercase()),
+                                &zig_cc,
+                            );
                         }
 
                         self.setup_os_deps()?;
@@ -357,7 +361,7 @@ impl Build {
                 }
             }
         }
-        
+
         Ok(build)
     }
 

--- a/src/build.rs
+++ b/src/build.rs
@@ -320,41 +320,43 @@ impl Build {
             // setup zig as linker
             let rustc_meta = rustc_version::version_meta()?;
             let host_target = &rustc_meta.host;
-            for full_target in rust_targets.iter() {
-                // we only setup zig as linker when target isn't exactly the same as host target
-                if host_target != full_target {
-                    let env_target = full_target.replace('-', "_");
-                    let (zig_cc, zig_cxx) = prepare_zig_linker(full_target)?;
-                    if is_mingw_shell() {
-                        let zig_cc = zig_cc.to_slash_lossy();
-                        build.env(format!("CC_{}", env_target), &zig_cc);
-                        build.env(format!("CXX_{}", env_target), &zig_cxx.to_slash_lossy());
-                        build.env(
-                            format!("CARGO_TARGET_{}_LINKER", env_target.to_uppercase()),
-                            &zig_cc,
-                        );
-                    } else {
-                        build.env(format!("CC_{}", env_target), &zig_cc);
-                        build.env(format!("CXX_{}", env_target), &zig_cxx);
-                        build.env(
-                            format!("CARGO_TARGET_{}_LINKER", env_target.to_uppercase()),
-                            &zig_cc,
-                        );
-                    }
+            for (i, parsed_target) in rust_targets.iter().enumerate() {
+                if let Some(raw_target) = self.target.get(i) {
+                    // we only setup zig as linker when target isn't exactly the same as host target
+                    if host_target != raw_target {
+                        let env_target = parsed_target.replace('-', "_");
+                        let (zig_cc, zig_cxx) = prepare_zig_linker(parsed_target)?;
+                        if is_mingw_shell() {
+                            let zig_cc = zig_cc.to_slash_lossy();
+                            build.env(format!("CC_{}", env_target), &zig_cc);
+                            build.env(format!("CXX_{}", env_target), &zig_cxx.to_slash_lossy());
+                            build.env(
+                                format!("CARGO_TARGET_{}_LINKER", env_target.to_uppercase()),
+                                &zig_cc,
+                            );
+                        } else {
+                            build.env(format!("CC_{}", env_target), &zig_cc);
+                            build.env(format!("CXX_{}", env_target), &zig_cxx);
+                            build.env(
+                                format!("CARGO_TARGET_{}_LINKER", env_target.to_uppercase()),
+                                &zig_cc,
+                            );
+                        }
 
-                    self.setup_os_deps()?;
+                        self.setup_os_deps()?;
 
-                    if full_target.contains("windows-gnu") {
-                        build.env("WINAPI_NO_BUNDLED_LIBRARIES", "1");
-                    }
+                        if raw_target.contains("windows-gnu") {
+                            build.env("WINAPI_NO_BUNDLED_LIBRARIES", "1");
+                        }
 
-                    // Enable unstable `target-applies-to-host` option automatically for nightly Rust
-                    // when target is the same as host but may have specified glibc version
-                    if host_target == full_target
-                        && matches!(rustc_meta.channel, rustc_version::Channel::Nightly)
-                    {
-                        build.env("CARGO_UNSTABLE_TARGET_APPLIES_TO_HOST", "true");
-                        build.env("CARGO_TARGET_APPLIES_TO_HOST", "false");
+                        // Enable unstable `target-applies-to-host` option automatically for nightly Rust
+                        // when target is the same as host but may have specified glibc version
+                        if host_target == raw_target
+                            && matches!(rustc_meta.channel, rustc_version::Channel::Nightly)
+                        {
+                            build.env("CARGO_UNSTABLE_TARGET_APPLIES_TO_HOST", "true");
+                            build.env("CARGO_TARGET_APPLIES_TO_HOST", "false");
+                        }
                     }
                 }
             }

--- a/src/build.rs
+++ b/src/build.rs
@@ -105,7 +105,12 @@ pub struct Build {
     pub no_default_features: bool,
 
     /// Build for the target triple
-    #[clap(long, value_name = "TRIPLE", env = "CARGO_BUILD_TARGET", multiple_occurrences = true )]
+    #[clap(
+        long,
+        value_name = "TRIPLE",
+        env = "CARGO_BUILD_TARGET",
+        multiple_occurrences = true
+    )]
     pub target: Option<Vec<String>>,
 
     /// Directory for all generated artifacts
@@ -190,14 +195,11 @@ impl Build {
         let mut build = Command::new("cargo");
         build.arg(subcommand);
 
-        let rust_targets = self
-            .target
-            .as_ref()
-            .map(|targets| {
-                targets.into_iter().map(|target| {
-                    target.split_once('.').map(|(t, _)| t).unwrap_or(target)
-                })
-            });
+        let rust_targets = self.target.as_ref().map(|targets| {
+            targets
+                .into_iter()
+                .map(|target| target.split_once('.').map(|(t, _)| t).unwrap_or(target))
+        });
 
         // collect cargo build arguments
         if self.quiet {
@@ -265,8 +267,7 @@ impl Build {
         }
         if let Some(rust_targets) = rust_targets {
             rust_targets.for_each(|target| {
-                build.arg("--target")
-                    .arg(&target);
+                build.arg("--target").arg(&target);
             });
         }
         if let Some(dir) = self.target_dir.as_ref() {
@@ -337,13 +338,13 @@ impl Build {
                                 build.env("TARGET_CXX", &zig_cxx);
                                 build.env(format!("CARGO_TARGET_{}_LINKER", env_target), &zig_cc);
                             }
-    
+
                             self.setup_os_deps()?;
-    
+
                             if rust_target.contains("windows-gnu") {
                                 build.env("WINAPI_NO_BUNDLED_LIBRARIES", "1");
                             }
-    
+
                             // Enable unstable `target-applies-to-host` option automatically for nightly Rust
                             // when target is the same as host but may have specified glibc version
                             if host_target == rust_target
@@ -355,7 +356,6 @@ impl Build {
                         }
                     }
                 }
-
             }
         }
         Ok(build)
@@ -407,7 +407,6 @@ impl Build {
                     }
                 }
             }
-
         }
         Ok(())
     }

--- a/src/build.rs
+++ b/src/build.rs
@@ -320,43 +320,41 @@ impl Build {
             // setup zig as linker
             let rustc_meta = rustc_version::version_meta()?;
             let host_target = &rustc_meta.host;
-            for (i, full_target) in rust_targets.iter().enumerate() {
+            for full_target in rust_targets.iter() {
                 // we only setup zig as linker when target isn't exactly the same as host target
                 if host_target != full_target {
-                    if let Some(rust_target) = rust_targets.get(i) {
-                        let env_target = rust_target.replace('-', "_");
-                        let (zig_cc, zig_cxx) = prepare_zig_linker(full_target)?;
-                        if is_mingw_shell() {
-                            let zig_cc = zig_cc.to_slash_lossy();
-                            build.env(format!("CC_{}", env_target), &zig_cc);
-                            build.env(format!("CXX_{}", env_target), &zig_cxx.to_slash_lossy());
-                            build.env(
-                                format!("CARGO_TARGET_{}_LINKER", env_target.to_uppercase()),
-                                &zig_cc,
-                            );
-                        } else {
-                            build.env(format!("CC_{}", env_target), &zig_cc);
-                            build.env(format!("CXX_{}", env_target), &zig_cxx);
-                            build.env(
-                                format!("CARGO_TARGET_{}_LINKER", env_target.to_uppercase()),
-                                &zig_cc,
-                            );
-                        }
+                    let env_target = full_target.replace('-', "_");
+                    let (zig_cc, zig_cxx) = prepare_zig_linker(full_target)?;
+                    if is_mingw_shell() {
+                        let zig_cc = zig_cc.to_slash_lossy();
+                        build.env(format!("CC_{}", env_target), &zig_cc);
+                        build.env(format!("CXX_{}", env_target), &zig_cxx.to_slash_lossy());
+                        build.env(
+                            format!("CARGO_TARGET_{}_LINKER", env_target.to_uppercase()),
+                            &zig_cc,
+                        );
+                    } else {
+                        build.env(format!("CC_{}", env_target), &zig_cc);
+                        build.env(format!("CXX_{}", env_target), &zig_cxx);
+                        build.env(
+                            format!("CARGO_TARGET_{}_LINKER", env_target.to_uppercase()),
+                            &zig_cc,
+                        );
+                    }
 
-                        self.setup_os_deps()?;
+                    self.setup_os_deps()?;
 
-                        if rust_target.contains("windows-gnu") {
-                            build.env("WINAPI_NO_BUNDLED_LIBRARIES", "1");
-                        }
+                    if full_target.contains("windows-gnu") {
+                        build.env("WINAPI_NO_BUNDLED_LIBRARIES", "1");
+                    }
 
-                        // Enable unstable `target-applies-to-host` option automatically for nightly Rust
-                        // when target is the same as host but may have specified glibc version
-                        if host_target == rust_target
-                            && matches!(rustc_meta.channel, rustc_version::Channel::Nightly)
-                        {
-                            build.env("CARGO_UNSTABLE_TARGET_APPLIES_TO_HOST", "true");
-                            build.env("CARGO_TARGET_APPLIES_TO_HOST", "false");
-                        }
+                    // Enable unstable `target-applies-to-host` option automatically for nightly Rust
+                    // when target is the same as host but may have specified glibc version
+                    if host_target == full_target
+                        && matches!(rustc_meta.channel, rustc_version::Channel::Nightly)
+                    {
+                        build.env("CARGO_UNSTABLE_TARGET_APPLIES_TO_HOST", "true");
+                        build.env("CARGO_TARGET_APPLIES_TO_HOST", "false");
                     }
                 }
             }

--- a/src/build.rs
+++ b/src/build.rs
@@ -111,7 +111,7 @@ pub struct Build {
         env = "CARGO_BUILD_TARGET",
         multiple_occurrences = true
     )]
-    pub target: Option<Vec<String>>,
+    pub target: Vec<String>,
 
     /// Directory for all generated artifacts
     #[clap(long, value_name = "DIRECTORY", parse(from_os_str))]
@@ -195,11 +195,10 @@ impl Build {
         let mut build = Command::new("cargo");
         build.arg(subcommand);
 
-        let rust_targets = self.target.as_ref().map(|targets| {
-            targets
-                .into_iter()
-                .map(|target| target.split_once('.').map(|(t, _)| t).unwrap_or(target))
-        });
+        let rust_targets = self
+            .target
+            .iter()
+            .map(|target| target.split_once('.').map(|(t, _)| t).unwrap_or(&target));
 
         // collect cargo build arguments
         if self.quiet {
@@ -265,11 +264,11 @@ impl Build {
         if self.no_default_features {
             build.arg("--no-default-features");
         }
-        if let Some(rust_targets) = rust_targets {
-            rust_targets.for_each(|target| {
-                build.arg("--target").arg(&target);
-            });
-        }
+
+        rust_targets.for_each(|target| {
+            build.arg("--target").arg(&target);
+        });
+
         if let Some(dir) = self.target_dir.as_ref() {
             build.arg("--target-dir").arg(dir);
         }
@@ -318,41 +317,39 @@ impl Build {
 
         if !self.disable_zig_linker {
             // setup zig as linker
-            if let Some(targets) = self.target.as_ref() {
-                let rustc_meta = rustc_version::version_meta()?;
-                let host_target = &rustc_meta.host;
-                // we only setup zig as linker when target isn't exactly the same as host target
+            let rustc_meta = rustc_version::version_meta()?;
+            let host_target = &rustc_meta.host;
+            // we only setup zig as linker when target isn't exactly the same as host target
 
-                for (i, full_target) in targets.iter().enumerate() {
-                    if host_target != full_target {
-                        if let Some(rust_target) = targets.get(i) {
-                            let env_target = rust_target.to_uppercase().replace('-', "_");
-                            let (zig_cc, zig_cxx) = prepare_zig_linker(full_target)?;
-                            if is_mingw_shell() {
-                                let zig_cc = zig_cc.to_slash_lossy();
-                                build.env("TARGET_CC", &zig_cc);
-                                build.env("TARGET_CXX", &zig_cxx.to_slash_lossy());
-                                build.env(format!("CARGO_TARGET_{}_LINKER", env_target), &zig_cc);
-                            } else {
-                                build.env("TARGET_CC", &zig_cc);
-                                build.env("TARGET_CXX", &zig_cxx);
-                                build.env(format!("CARGO_TARGET_{}_LINKER", env_target), &zig_cc);
-                            }
+            for (i, full_target) in self.target.iter().enumerate() {
+                if host_target != full_target {
+                    if let Some(rust_target) = self.target.get(i) {
+                        let env_target = rust_target.to_uppercase().replace('-', "_");
+                        let (zig_cc, zig_cxx) = prepare_zig_linker(full_target)?;
+                        if is_mingw_shell() {
+                            let zig_cc = zig_cc.to_slash_lossy();
+                            build.env("TARGET_CC", &zig_cc);
+                            build.env("TARGET_CXX", &zig_cxx.to_slash_lossy());
+                            build.env(format!("CARGO_TARGET_{}_LINKER", env_target), &zig_cc);
+                        } else {
+                            build.env("TARGET_CC", &zig_cc);
+                            build.env("TARGET_CXX", &zig_cxx);
+                            build.env(format!("CARGO_TARGET_{}_LINKER", env_target), &zig_cc);
+                        }
 
-                            self.setup_os_deps()?;
+                        self.setup_os_deps()?;
 
-                            if rust_target.contains("windows-gnu") {
-                                build.env("WINAPI_NO_BUNDLED_LIBRARIES", "1");
-                            }
+                        if rust_target.contains("windows-gnu") {
+                            build.env("WINAPI_NO_BUNDLED_LIBRARIES", "1");
+                        }
 
-                            // Enable unstable `target-applies-to-host` option automatically for nightly Rust
-                            // when target is the same as host but may have specified glibc version
-                            if host_target == rust_target
-                                && matches!(rustc_meta.channel, rustc_version::Channel::Nightly)
-                            {
-                                build.env("CARGO_UNSTABLE_TARGET_APPLIES_TO_HOST", "true");
-                                build.env("CARGO_TARGET_APPLIES_TO_HOST", "false");
-                            }
+                        // Enable unstable `target-applies-to-host` option automatically for nightly Rust
+                        // when target is the same as host but may have specified glibc version
+                        if host_target == rust_target
+                            && matches!(rustc_meta.channel, rustc_version::Channel::Nightly)
+                        {
+                            build.env("CARGO_UNSTABLE_TARGET_APPLIES_TO_HOST", "true");
+                            build.env("CARGO_TARGET_APPLIES_TO_HOST", "false");
                         }
                     }
                 }
@@ -362,48 +359,46 @@ impl Build {
     }
 
     fn setup_os_deps(&self) -> Result<()> {
-        if let Some(full_targets) = self.target.as_ref() {
-            for target in full_targets.into_iter() {
-                if target.contains("apple") {
-                    let target_dir = if let Some(target_dir) = self.target_dir.clone() {
-                        target_dir.join(target)
-                    } else {
-                        let manifest_path = self
-                            .manifest_path
-                            .as_deref()
-                            .unwrap_or_else(|| Path::new("Cargo.toml"));
-                        let mut metadata_cmd = cargo_metadata::MetadataCommand::new();
-                        metadata_cmd.manifest_path(&manifest_path);
-                        let metadata = metadata_cmd.exec()?;
-                        metadata.target_directory.into_std_path_buf().join(target)
-                    };
-                    let profile = match self.profile.as_deref() {
-                        Some("dev" | "test") => "debug",
-                        Some("release" | "bench") => "release",
-                        Some(profile) => profile,
-                        None => {
-                            if self.release {
-                                "release"
-                            } else {
-                                "debug"
-                            }
+        for target in &self.target {
+            if target.contains("apple") {
+                let target_dir = if let Some(target_dir) = self.target_dir.clone() {
+                    target_dir.join(target)
+                } else {
+                    let manifest_path = self
+                        .manifest_path
+                        .as_deref()
+                        .unwrap_or_else(|| Path::new("Cargo.toml"));
+                    let mut metadata_cmd = cargo_metadata::MetadataCommand::new();
+                    metadata_cmd.manifest_path(&manifest_path);
+                    let metadata = metadata_cmd.exec()?;
+                    metadata.target_directory.into_std_path_buf().join(target)
+                };
+                let profile = match self.profile.as_deref() {
+                    Some("dev" | "test") => "debug",
+                    Some("release" | "bench") => "release",
+                    Some(profile) => profile,
+                    None => {
+                        if self.release {
+                            "release"
+                        } else {
+                            "debug"
                         }
-                    };
-                    let deps_dir = target_dir.join(profile).join("deps");
-                    fs::create_dir_all(&deps_dir)?;
-                    fs::write(deps_dir.join("libiconv.tbd"), LIBICONV_TBD)?;
-                } else if target.contains("arm") && target.contains("linux") {
-                    // See https://github.com/ziglang/zig/issues/3287
-                    if let Ok(lib_dir) = Zig::lib_dir() {
-                        let arm_features_h = lib_dir
-                            .join("libc")
-                            .join("glibc")
-                            .join("sysdeps")
-                            .join("arm")
-                            .join("arm-features.h");
-                        if !arm_features_h.is_file() {
-                            fs::write(arm_features_h, ARM_FEATURES_H)?;
-                        }
+                    }
+                };
+                let deps_dir = target_dir.join(profile).join("deps");
+                fs::create_dir_all(&deps_dir)?;
+                fs::write(deps_dir.join("libiconv.tbd"), LIBICONV_TBD)?;
+            } else if target.contains("arm") && target.contains("linux") {
+                // See https://github.com/ziglang/zig/issues/3287
+                if let Ok(lib_dir) = Zig::lib_dir() {
+                    let arm_features_h = lib_dir
+                        .join("libc")
+                        .join("glibc")
+                        .join("sysdeps")
+                        .join("arm")
+                        .join("arm-features.h");
+                    if !arm_features_h.is_file() {
+                        fs::write(arm_features_h, ARM_FEATURES_H)?;
                     }
                 }
             }

--- a/src/build.rs
+++ b/src/build.rs
@@ -357,7 +357,6 @@ impl Build {
                         build.env("CARGO_TARGET_APPLIES_TO_HOST", "false");
                     }
                 }
-                
             }
         }
 

--- a/src/build.rs
+++ b/src/build.rs
@@ -320,45 +320,44 @@ impl Build {
             // setup zig as linker
             let rustc_meta = rustc_version::version_meta()?;
             let host_target = &rustc_meta.host;
-            for (i, parsed_target) in rust_targets.iter().enumerate() {
-                if let Some(raw_target) = self.target.get(i) {
-                    // we only setup zig as linker when target isn't exactly the same as host target
-                    if host_target != raw_target {
-                        let env_target = parsed_target.replace('-', "_");
-                        let (zig_cc, zig_cxx) = prepare_zig_linker(raw_target)?;
-                        if is_mingw_shell() {
-                            let zig_cc = zig_cc.to_slash_lossy();
-                            build.env(format!("CC_{}", env_target), &zig_cc);
-                            build.env(format!("CXX_{}", env_target), &zig_cxx.to_slash_lossy());
-                            build.env(
-                                format!("CARGO_TARGET_{}_LINKER", env_target.to_uppercase()),
-                                &zig_cc,
-                            );
-                        } else {
-                            build.env(format!("CC_{}", env_target), &zig_cc);
-                            build.env(format!("CXX_{}", env_target), &zig_cxx);
-                            build.env(
-                                format!("CARGO_TARGET_{}_LINKER", env_target.to_uppercase()),
-                                &zig_cc,
-                            );
-                        }
+            for (parsed_target, raw_target) in rust_targets.iter().zip(&self.target) {
+                // we only setup zig as linker when target isn't exactly the same as host target
+                if host_target != raw_target {
+                    let env_target = parsed_target.replace('-', "_");
+                    let (zig_cc, zig_cxx) = prepare_zig_linker(raw_target)?;
+                    if is_mingw_shell() {
+                        let zig_cc = zig_cc.to_slash_lossy();
+                        build.env(format!("CC_{}", env_target), &zig_cc);
+                        build.env(format!("CXX_{}", env_target), &zig_cxx.to_slash_lossy());
+                        build.env(
+                            format!("CARGO_TARGET_{}_LINKER", env_target.to_uppercase()),
+                            &zig_cc,
+                        );
+                    } else {
+                        build.env(format!("CC_{}", env_target), &zig_cc);
+                        build.env(format!("CXX_{}", env_target), &zig_cxx);
+                        build.env(
+                            format!("CARGO_TARGET_{}_LINKER", env_target.to_uppercase()),
+                            &zig_cc,
+                        );
+                    }
 
-                        self.setup_os_deps()?;
+                    self.setup_os_deps()?;
 
-                        if raw_target.contains("windows-gnu") {
-                            build.env("WINAPI_NO_BUNDLED_LIBRARIES", "1");
-                        }
+                    if raw_target.contains("windows-gnu") {
+                        build.env("WINAPI_NO_BUNDLED_LIBRARIES", "1");
+                    }
 
-                        // Enable unstable `target-applies-to-host` option automatically for nightly Rust
-                        // when target is the same as host but may have specified glibc version
-                        if host_target == raw_target
-                            && matches!(rustc_meta.channel, rustc_version::Channel::Nightly)
-                        {
-                            build.env("CARGO_UNSTABLE_TARGET_APPLIES_TO_HOST", "true");
-                            build.env("CARGO_TARGET_APPLIES_TO_HOST", "false");
-                        }
+                    // Enable unstable `target-applies-to-host` option automatically for nightly Rust
+                    // when target is the same as host but may have specified glibc version
+                    if host_target == raw_target
+                        && matches!(rustc_meta.channel, rustc_version::Channel::Nightly)
+                    {
+                        build.env("CARGO_UNSTABLE_TARGET_APPLIES_TO_HOST", "true");
+                        build.env("CARGO_TARGET_APPLIES_TO_HOST", "false");
                     }
                 }
+                
             }
         }
 

--- a/src/build.rs
+++ b/src/build.rs
@@ -198,7 +198,9 @@ impl Build {
         let rust_targets = self
             .target
             .iter()
-            .map(|target| target.split_once('.').map(|(t, _)| t).unwrap_or(&target))
+            .map(|target| {
+                target.split_once('.').map(|(t, _)| t).unwrap_or(&target)
+            })
             .collect::<Vec<&str>>();
 
         // collect cargo build arguments
@@ -324,16 +326,16 @@ impl Build {
                 // we only setup zig as linker when target isn't exactly the same as host target
                 if host_target != full_target {
                     if let Some(rust_target) = rust_targets.get(i) {
-                        let env_target = rust_target.replace('-', "_");
+                        let env_target = rust_target.to_uppercase().replace('-', "_");
                         let (zig_cc, zig_cxx) = prepare_zig_linker(full_target)?;
                         if is_mingw_shell() {
                             let zig_cc = zig_cc.to_slash_lossy();
-                            build.env(format!("CC_{}", env_target), &zig_cc);
-                            build.env(format!("CXX_{}", env_target), &zig_cxx.to_slash_lossy());
+                            build.env(format!("CC_{}", env_target.to_lowercase()), &zig_cc);
+                            build.env(format!("CXX_{}", env_target.to_lowercase()), &zig_cxx.to_slash_lossy());
                             build.env(format!("CARGO_TARGET_{}_LINKER", env_target), &zig_cc);
                         } else {
-                            build.env(format!("CC_{}", env_target), &zig_cc);
-                            build.env(format!("CXX_{}", env_target), &zig_cxx);
+                            build.env(format!("CC_{}", env_target.to_lowercase()), &zig_cc);
+                            build.env(format!("CXX_{}", env_target.to_lowercase()), &zig_cxx);
                             build.env(format!("CARGO_TARGET_{}_LINKER", env_target), &zig_cc);
                         }
 
@@ -355,7 +357,7 @@ impl Build {
                 }
             }
         }
-
+        
         Ok(build)
     }
 

--- a/src/build.rs
+++ b/src/build.rs
@@ -325,7 +325,7 @@ impl Build {
                     // we only setup zig as linker when target isn't exactly the same as host target
                     if host_target != raw_target {
                         let env_target = parsed_target.replace('-', "_");
-                        let (zig_cc, zig_cxx) = prepare_zig_linker(parsed_target)?;
+                        let (zig_cc, zig_cxx) = prepare_zig_linker(raw_target)?;
                         if is_mingw_shell() {
                             let zig_cc = zig_cc.to_slash_lossy();
                             build.env(format!("CC_{}", env_target), &zig_cc);

--- a/src/build.rs
+++ b/src/build.rs
@@ -198,9 +198,7 @@ impl Build {
         let rust_targets = self
             .target
             .iter()
-            .map(|target| {
-                target.split_once('.').map(|(t, _)| t).unwrap_or(&target)
-            })
+            .map(|target| target.split_once('.').map(|(t, _)| t).unwrap_or(&target))
             .collect::<Vec<&str>>();
 
         // collect cargo build arguments
@@ -326,7 +324,7 @@ impl Build {
                 // we only setup zig as linker when target isn't exactly the same as host target
                 if host_target != full_target {
                     if let Some(rust_target) = rust_targets.get(i) {
-                        let env_target = rust_target.to_uppercase().replace('-', "_");
+                        let env_target = rust_target.replace('-', "_");
                         let (zig_cc, zig_cxx) = prepare_zig_linker(full_target)?;
                         if is_mingw_shell() {
                             let zig_cc = zig_cc.to_slash_lossy();
@@ -357,6 +355,7 @@ impl Build {
                 }
             }
         }
+
         Ok(build)
     }
 

--- a/src/rustc.rs
+++ b/src/rustc.rs
@@ -88,7 +88,12 @@ pub struct Rustc {
     pub no_default_features: bool,
 
     /// Build for the target triple
-    #[clap(long, value_name = "TRIPLE", env = "CARGO_BUILD_TARGET", multiple_occurrences = true)]
+    #[clap(
+        long,
+        value_name = "TRIPLE",
+        env = "CARGO_BUILD_TARGET",
+        multiple_occurrences = true
+    )]
     pub target: Option<Vec<String>>,
 
     /// Output compiler information without compiling

--- a/src/rustc.rs
+++ b/src/rustc.rs
@@ -94,7 +94,7 @@ pub struct Rustc {
         env = "CARGO_BUILD_TARGET",
         multiple_occurrences = true
     )]
-    pub target: Option<Vec<String>>,
+    pub target: Vec<String>,
 
     /// Output compiler information without compiling
     #[clap(long, value_name = "INFO")]

--- a/src/rustc.rs
+++ b/src/rustc.rs
@@ -88,8 +88,8 @@ pub struct Rustc {
     pub no_default_features: bool,
 
     /// Build for the target triple
-    #[clap(long, value_name = "TRIPLE", env = "CARGO_BUILD_TARGET")]
-    pub target: Option<String>,
+    #[clap(long, value_name = "TRIPLE", env = "CARGO_BUILD_TARGET", multiple_occurrences = true)]
+    pub target: Option<Vec<String>>,
 
     /// Output compiler information without compiling
     #[clap(long, value_name = "INFO")]

--- a/src/zig.rs
+++ b/src/zig.rs
@@ -53,6 +53,7 @@ impl Zig {
             .map(|x| x.contains("windows-gnu"))
             .unwrap_or_default();
         let is_arm = target.map(|x| x.contains("arm")).unwrap_or_default();
+        let is_macos = target.map(|x| x.contains("macos")).unwrap_or_default();
 
         let rustc_ver = rustc_version::version()?;
 
@@ -126,6 +127,17 @@ impl Zig {
         }
         if has_undefined_dynamic_lookup(cmd_args) {
             new_cmd_args.push("-Wl,-undefined=dynamic_lookup".to_string());
+        }
+
+        if is_macos {
+            if let Ok(sdkroot) = env::var("SDKROOT") {
+                new_cmd_args.extend_from_slice(&[
+                    format!("--sysroot={}", sdkroot),
+                    "-I/usr/include".to_string(),
+                    "-L/usr/lib".to_string(),
+                    "-F/System/Library/Frameworks".to_string(),
+                ]);
+            }
         }
 
         let mut child = Self::command()?


### PR DESCRIPTION
First of all I want to say thank you for this incredible tool, it made our work so much easier.

As a part of our pipe line we need to build our program to multiple targets, recently a change has been made to the `cargo` cli allowing to pass a flag called `multitarget` which makes it possible to compile to multiple targets all at once.

The proposed changes follow the way the `cargo build` CLI works, see: 
https://github.dev/rust-lang/cargo/blob/06b9d31743210b788b130c8a484c2838afa6fc27/src/bin/cargo/commands/build.rs

```rs
    fn arg_target_triple(self, target: &'static str) -> Self {
        self._arg(multi_opt("target", "TRIPLE", target))
    }

pub fn multi_opt(name: &'static str, value_name: &'static str, help: &'static str) -> Arg<'static> {
    opt(name, help)
        .value_name(value_name)
        .multiple_occurrences(true)
}
``` 

suggesting that `target` should infact be a flag which may occur N >= 1 amount of times.

This pull request makes it possible to run the next:
`cargo-zigbuild.exe build -Zmultitarget --target x86_64-pc-windows-msvc --target x86_64-unknown-linux-musl --release`