### PR TITLE
Remove double dot from linker wrapper.

### DIFF
--- a/src/zig.rs
+++ b/src/zig.rs
@@ -458,8 +458,9 @@ pub fn prepare_zig_linker(target: &str) -> Result<(PathBuf, PathBuf)> {
         (_, environment) => environment,
     };
     let file_ext = if cfg!(windows) { "bat" } else { "sh" };
-    let zig_cc = format!("zigcc-{}.{}", target, file_ext);
-    let zig_cxx = format!("zigcxx-{}.{}", target, file_ext);
+    let file_target = target.trim_end_matches('.');
+    let zig_cc = format!("zigcc-{}.{}", file_target, file_ext);
+    let zig_cxx = format!("zigcxx-{}.{}", file_target, file_ext);
     let cc_args = "-g"; // prevent stripping
     let mut cc_args = match triple.operating_system {
         OperatingSystem::Linux => format!(


### PR DESCRIPTION
Instead of generating names like `zigcc-x86_64-unknown-linux-gnu..sh`, generates names like `zigcc-x86_64-unknown-linux-gnu.sh`.

Signed-off-by: David Calavera <david.calavera@gmail.com>