### PR TITLE
Add x86_64-pc-windows-gnu to Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -38,6 +38,7 @@ RUN rustup target add \
     arm-unknown-linux-gnueabihf \
     arm-unknown-linux-musleabihf \
     x86_64-apple-darwin \
-    aarch64-apple-darwin
+    aarch64-apple-darwin \
+    x86_64-pc-windows-gnu
 
 COPY --from=builder /cargo-zigbuild/target/release/cargo-zigbuild /usr/local/cargo/bin/


### PR DESCRIPTION
I want to build target `x86_64-pc-windows-gnu`, but the Docker image doesn't have `x86_64-pc-windows-gnu`.
I add it to Dockerfile :)