### PR TITLE
Only enable `zig ar` in cargo-zigbuild binary by default

### DIFF
--- a/src/bin/cargo-zigbuild.rs
+++ b/src/bin/cargo-zigbuild.rs
@@ -37,16 +37,11 @@ fn main() -> anyhow::Result<()> {
             args: args.collect(),
         };
         zig.execute()?;
-    } else if program_name.eq_ignore_ascii_case("ranlib") {
-        let zig = Zig::Ranlib {
-            args: args.collect(),
-        };
-        zig.execute()?;
     } else {
         let opt = Opt::parse();
         match opt {
             Opt::Build(mut build) => {
-                build.enable_zig_tools = true;
+                build.enable_zig_ar = true;
                 build.execute()?
             }
             Opt::Metadata(metadata) => {
@@ -60,15 +55,15 @@ fn main() -> anyhow::Result<()> {
                 }
             }
             Opt::Rustc(mut rustc) => {
-                rustc.enable_zig_tools = true;
+                rustc.enable_zig_ar = true;
                 rustc.execute()?
             }
             Opt::Run(mut run) => {
-                run.enable_zig_tools = true;
+                run.enable_zig_ar = true;
                 run.execute()?
             }
             Opt::Test(mut test) => {
-                test.enable_zig_tools = true;
+                test.enable_zig_ar = true;
                 test.execute()?
             }
             Opt::Zig(zig) => zig.execute()?,

--- a/src/bin/cargo-zigbuild.rs
+++ b/src/bin/cargo-zigbuild.rs
@@ -45,7 +45,10 @@ fn main() -> anyhow::Result<()> {
     } else {
         let opt = Opt::parse();
         match opt {
-            Opt::Build(build) => build.execute()?,
+            Opt::Build(mut build) => {
+                build.enable_zig_tools = true;
+                build.execute()?
+            }
             Opt::Metadata(metadata) => {
                 let mut cmd = metadata.command();
                 let mut child = cmd.spawn().context("Failed to run cargo metadata")?;
@@ -56,9 +59,18 @@ fn main() -> anyhow::Result<()> {
                     std::process::exit(status.code().unwrap_or(1));
                 }
             }
-            Opt::Rustc(rustc) => rustc.execute()?,
-            Opt::Run(run) => run.execute()?,
-            Opt::Test(test) => test.execute()?,
+            Opt::Rustc(mut rustc) => {
+                rustc.enable_zig_tools = true;
+                rustc.execute()?
+            }
+            Opt::Run(mut run) => {
+                run.enable_zig_tools = true;
+                run.execute()?
+            }
+            Opt::Test(mut test) => {
+                test.enable_zig_tools = true;
+                test.execute()?
+            }
             Opt::Zig(zig) => zig.execute()?,
         }
     }

--- a/src/build.rs
+++ b/src/build.rs
@@ -19,9 +19,9 @@ pub struct Build {
     #[clap(skip)]
     pub disable_zig_linker: bool,
 
-    /// Enable zig tools (ar, ranlib)
+    /// Enable zig ar
     #[clap(skip)]
-    pub enable_zig_tools: bool,
+    pub enable_zig_ar: bool,
 }
 
 impl Build {
@@ -48,7 +48,7 @@ impl Build {
     pub fn build_command(&self) -> Result<Command> {
         let mut build = self.cargo.command();
         if !self.disable_zig_linker {
-            Zig::apply_command_env(&self.cargo.common, &mut build, self.enable_zig_tools)?;
+            Zig::apply_command_env(&self.cargo.common, &mut build, self.enable_zig_ar)?;
         }
 
         Ok(build)

--- a/src/build.rs
+++ b/src/build.rs
@@ -18,6 +18,10 @@ pub struct Build {
     /// Disable zig linker
     #[clap(skip)]
     pub disable_zig_linker: bool,
+
+    /// Enable zig tools (ar, ranlib)
+    #[clap(skip)]
+    pub enable_zig_tools: bool,
 }
 
 impl Build {
@@ -44,7 +48,7 @@ impl Build {
     pub fn build_command(&self) -> Result<Command> {
         let mut build = self.cargo.command();
         if !self.disable_zig_linker {
-            Zig::apply_command_env(&self.cargo.common, &mut build)?;
+            Zig::apply_command_env(&self.cargo.common, &mut build, self.enable_zig_tools)?;
         }
 
         Ok(build)
@@ -69,7 +73,7 @@ impl From<cargo_options::Build> for Build {
     fn from(cargo: cargo_options::Build) -> Self {
         Self {
             cargo,
-            disable_zig_linker: false,
+            ..Default::default()
         }
     }
 }

--- a/src/run.rs
+++ b/src/run.rs
@@ -19,9 +19,9 @@ pub struct Run {
     #[clap(skip)]
     pub disable_zig_linker: bool,
 
-    /// Enable zig tools (ar, ranlib)
+    /// Enable zig ar
     #[clap(skip)]
-    pub enable_zig_tools: bool,
+    pub enable_zig_ar: bool,
 
     #[clap(flatten)]
     pub cargo: cargo_options::Run,
@@ -52,7 +52,7 @@ impl Run {
     pub fn build_command(&self) -> Result<Command> {
         let mut build = self.cargo.command();
         if !self.disable_zig_linker {
-            Zig::apply_command_env(&self.cargo.common, &mut build, self.enable_zig_tools)?;
+            Zig::apply_command_env(&self.cargo.common, &mut build, self.enable_zig_ar)?;
         }
 
         Ok(build)

--- a/src/run.rs
+++ b/src/run.rs
@@ -19,6 +19,10 @@ pub struct Run {
     #[clap(skip)]
     pub disable_zig_linker: bool,
 
+    /// Enable zig tools (ar, ranlib)
+    #[clap(skip)]
+    pub enable_zig_tools: bool,
+
     #[clap(flatten)]
     pub cargo: cargo_options::Run,
 }
@@ -48,7 +52,7 @@ impl Run {
     pub fn build_command(&self) -> Result<Command> {
         let mut build = self.cargo.command();
         if !self.disable_zig_linker {
-            Zig::apply_command_env(&self.cargo.common, &mut build)?;
+            Zig::apply_command_env(&self.cargo.common, &mut build, self.enable_zig_tools)?;
         }
 
         Ok(build)

--- a/src/rustc.rs
+++ b/src/rustc.rs
@@ -20,6 +20,10 @@ pub struct Rustc {
     #[clap(skip)]
     pub disable_zig_linker: bool,
 
+    /// Enable zig tools (ar, ranlib)
+    #[clap(skip)]
+    pub enable_zig_tools: bool,
+
     #[clap(flatten)]
     pub cargo: cargo_options::Rustc,
 }
@@ -49,7 +53,7 @@ impl Rustc {
     pub fn build_command(&self) -> Result<Command> {
         let mut build = self.cargo.command();
         if !self.disable_zig_linker {
-            Zig::apply_command_env(&self.cargo.common, &mut build)?;
+            Zig::apply_command_env(&self.cargo.common, &mut build, self.enable_zig_tools)?;
         }
 
         Ok(build)

--- a/src/rustc.rs
+++ b/src/rustc.rs
@@ -20,9 +20,9 @@ pub struct Rustc {
     #[clap(skip)]
     pub disable_zig_linker: bool,
 
-    /// Enable zig tools (ar, ranlib)
+    /// Enable zig ar
     #[clap(skip)]
-    pub enable_zig_tools: bool,
+    pub enable_zig_ar: bool,
 
     #[clap(flatten)]
     pub cargo: cargo_options::Rustc,
@@ -53,7 +53,7 @@ impl Rustc {
     pub fn build_command(&self) -> Result<Command> {
         let mut build = self.cargo.command();
         if !self.disable_zig_linker {
-            Zig::apply_command_env(&self.cargo.common, &mut build, self.enable_zig_tools)?;
+            Zig::apply_command_env(&self.cargo.common, &mut build, self.enable_zig_ar)?;
         }
 
         Ok(build)

--- a/src/test.rs
+++ b/src/test.rs
@@ -19,6 +19,10 @@ pub struct Test {
     #[clap(skip)]
     pub disable_zig_linker: bool,
 
+    /// Enable zig tools (ar, ranlib)
+    #[clap(skip)]
+    pub enable_zig_tools: bool,
+
     #[clap(flatten)]
     pub cargo: cargo_options::Test,
 }
@@ -48,7 +52,7 @@ impl Test {
     pub fn build_command(&self) -> Result<Command> {
         let mut build = self.cargo.command();
         if !self.disable_zig_linker {
-            Zig::apply_command_env(&self.cargo.common, &mut build)?;
+            Zig::apply_command_env(&self.cargo.common, &mut build, self.enable_zig_tools)?;
         }
 
         Ok(build)

--- a/src/test.rs
+++ b/src/test.rs
@@ -19,9 +19,9 @@ pub struct Test {
     #[clap(skip)]
     pub disable_zig_linker: bool,
 
-    /// Enable zig tools (ar, ranlib)
+    /// Enable zig ar
     #[clap(skip)]
-    pub enable_zig_tools: bool,
+    pub enable_zig_ar: bool,
 
     #[clap(flatten)]
     pub cargo: cargo_options::Test,
@@ -52,7 +52,7 @@ impl Test {
     pub fn build_command(&self) -> Result<Command> {
         let mut build = self.cargo.command();
         if !self.disable_zig_linker {
-            Zig::apply_command_env(&self.cargo.common, &mut build, self.enable_zig_tools)?;
+            Zig::apply_command_env(&self.cargo.common, &mut build, self.enable_zig_ar)?;
         }
 
         Ok(build)


### PR DESCRIPTION
If `cargo-zigbuild` is used as library, `zig ar` is opt-in.