### PR TITLE
Add cargo-clippy, cargo-check support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -37,8 +37,7 @@ dependencies = [
 [[package]]
 name = "cargo-options"
 version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6755badfe5e0224c6e2ae710d82cd7dce5866e8ebcb22e5f3eced8f25fbd1ace"
+source = "git+https://github.com/oldgalileo/cargo-options?branch=galileo/add-clippy#be6f52e6008a2571fe04cb54e6bfc1e88f456765"
 dependencies = [
  "clap",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -37,7 +37,7 @@ dependencies = [
 [[package]]
 name = "cargo-options"
 version = "0.5.2"
-source = "git+https://github.com/oldgalileo/cargo-options?branch=galileo/add-clippy#be6f52e6008a2571fe04cb54e6bfc1e88f456765"
+source = "git+https://github.com/oldgalileo/cargo-options?branch=galileo/add-clippy#23e7afc95820e53d7982faf29f4e38504420aee9"
 dependencies = [
  "clap",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ rust-version = "1.61"
 
 [dependencies]
 anyhow = "1.0.53"
-cargo-options = { version = "0.5.2", git = "https://github.com/oldgalileo/cargo-options", branch = "galileo/add-clippy" }
+cargo-options = "0.5.3"
 cargo_metadata = "0.15.0"
 clap = { version = "4.0.0", features = ["derive", "env", "wrap_help"] }
 dirs = "4.0.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ rust-version = "1.61"
 
 [dependencies]
 anyhow = "1.0.53"
-cargo-options = "0.5.2"
+cargo-options = { version = "0.5.2", git = "https://github.com/oldgalileo/cargo-options", branch = "galileo/add-clippy" }
 cargo_metadata = "0.15.0"
 clap = { version = "4.0.0", features = ["derive", "env", "wrap_help"] }
 dirs = "4.0.0"

--- a/src/bin/cargo-zigbuild.rs
+++ b/src/bin/cargo-zigbuild.rs
@@ -3,7 +3,7 @@ use std::path::PathBuf;
 
 use anyhow::Context;
 use cargo_options::Metadata;
-use cargo_zigbuild::{Build, Run, Rustc, Test, Zig};
+use cargo_zigbuild::{Build, Clippy, Run, Rustc, Test, Zig};
 use clap::Parser;
 
 #[allow(clippy::large_enum_variant)]
@@ -12,6 +12,8 @@ use clap::Parser;
 pub enum Opt {
     #[command(name = "zigbuild", aliases = &["build", "b"] )]
     Build(Build),
+    #[command(name = "clippy")]
+    Clippy(Clippy),
     #[command(name = "metadata")]
     Metadata(Metadata),
     #[command(name = "rustc")]
@@ -39,6 +41,10 @@ fn main() -> anyhow::Result<()> {
             Opt::Build(mut build) => {
                 build.enable_zig_ar = true;
                 build.execute()?
+            }
+            Opt::Clippy(mut clippy) => {
+                clippy.enable_zig_ar = true;
+                clippy.execute()?
             }
             Opt::Metadata(metadata) => {
                 let mut cmd = metadata.command();

--- a/src/check.rs
+++ b/src/check.rs
@@ -10,11 +10,11 @@ use crate::Zig;
 #[derive(Clone, Debug, Default, Parser)]
 #[command(
     display_order = 1,
-    after_help = "Run `cargo help clippy` for more detailed information."
+    after_help = "Run `cargo help check` for more detailed information."
 )]
-pub struct Clippy {
+pub struct Check {
     #[command(flatten)]
-    pub cargo: cargo_options::Clippy,
+    pub cargo: cargo_options::Check,
 
     /// Disable zig linker
     #[arg(skip)]
@@ -25,8 +25,8 @@ pub struct Clippy {
     pub enable_zig_ar: bool,
 }
 
-impl Clippy {
-    /// Create a new run from manifest path
+impl Check {
+    /// Create a new check from manifest path
     #[allow(clippy::field_reassign_with_default)]
     pub fn new(manifest_path: Option<PathBuf>) -> Self {
         let mut build = Self::default();
@@ -34,14 +34,12 @@ impl Clippy {
         build
     }
 
-    /// Execute `cargo clippy` command
+    /// Execute `cargo check` command
     pub fn execute(&self) -> Result<()> {
         let mut run = self.build_command()?;
 
-        let mut child = run.spawn().context("Failed to run cargo clippy")?;
-        let status = child
-            .wait()
-            .expect("Failed to wait on cargo clippy process");
+        let mut child = run.spawn().context("Failed to run cargo check")?;
+        let status = child.wait().expect("Failed to wait on cargo check process");
         if !status.success() {
             process::exit(status.code().unwrap_or(1));
         }
@@ -59,22 +57,22 @@ impl Clippy {
     }
 }
 
-impl Deref for Clippy {
-    type Target = cargo_options::Clippy;
+impl Deref for Check {
+    type Target = cargo_options::Check;
 
     fn deref(&self) -> &Self::Target {
         &self.cargo
     }
 }
 
-impl DerefMut for Clippy {
+impl DerefMut for Check {
     fn deref_mut(&mut self) -> &mut Self::Target {
         &mut self.cargo
     }
 }
 
-impl From<cargo_options::Clippy> for Clippy {
-    fn from(cargo: cargo_options::Clippy) -> Self {
+impl From<cargo_options::Check> for Check {
+    fn from(cargo: cargo_options::Check) -> Self {
         Self {
             cargo,
             ..Default::default()

--- a/src/clippy.rs
+++ b/src/clippy.rs
@@ -1,0 +1,81 @@
+use std::ops::{Deref, DerefMut};
+use std::path::PathBuf;
+use std::process::{self, Command};
+
+use anyhow::{Context, Result};
+use clap::Parser;
+
+use crate::Zig;
+
+#[derive(Clone, Debug, Default, Parser)]
+#[command(
+    display_order = 1,
+    after_help = "Run `cargo help clippy` for more detailed information."
+)]
+pub struct Clippy {
+    #[command(flatten)]
+    pub cargo: cargo_options::Clippy,
+
+    /// Disable zig linker
+    #[arg(skip)]
+    pub disable_zig_linker: bool,
+
+    /// Enable zig ar
+    #[arg(skip)]
+    pub enable_zig_ar: bool,
+}
+
+impl Clippy {
+    /// Create a new run from manifest path
+    #[allow(clippy::field_reassign_with_default)]
+    pub fn new(manifest_path: Option<PathBuf>) -> Self {
+        let mut build = Self::default();
+        build.manifest_path = manifest_path;
+        build
+    }
+
+    /// Execute `cargo run` command
+    pub fn execute(&self) -> Result<()> {
+        let mut run = self.build_command()?;
+
+        let mut child = run.spawn().context("Failed to run cargo run")?;
+        let status = child.wait().expect("Failed to wait on cargo run process");
+        if !status.success() {
+            process::exit(status.code().unwrap_or(1));
+        }
+        Ok(())
+    }
+
+    /// Generate cargo subcommand
+    pub fn build_command(&self) -> Result<Command> {
+        let mut build = self.cargo.command();
+        if !self.disable_zig_linker {
+            Zig::apply_command_env(&self.cargo.common, &mut build, self.enable_zig_ar)?;
+        }
+
+        Ok(build)
+    }
+}
+
+impl Deref for Clippy {
+    type Target = cargo_options::Clippy;
+
+    fn deref(&self) -> &Self::Target {
+        &self.cargo
+    }
+}
+
+impl DerefMut for Clippy {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.cargo
+    }
+}
+
+impl From<cargo_options::Clippy> for Clippy {
+    fn from(cargo: cargo_options::Clippy) -> Self {
+        Self {
+            cargo,
+            ..Default::default()
+        }
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,5 @@
 mod build;
+mod clippy;
 pub mod linux;
 pub mod macos;
 mod run;
@@ -6,6 +7,7 @@ mod rustc;
 mod test;
 pub mod zig;
 
+pub use crate::clippy::Clippy;
 pub use build::Build;
 pub use run::Run;
 pub use rustc::Rustc;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,5 @@
 mod build;
+mod check;
 mod clippy;
 pub mod linux;
 pub mod macos;


### PR DESCRIPTION
Originally added basic clippy support. https://github.com/messense/cargo-zigbuild/pull/73/commits/e43e7afc4d564fa1e1d642139edeca630e0bcdff included `cargo-check` as a natural byproduct of supporting the full option set of `cargo-clippy`

See [messense/cargo-options#5](https://github.com/messense/cargo-options/pull/5) for discussion